### PR TITLE
feature: introduce monkey patcher to make adapters configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,16 @@ You have been warned - use at your own risk.
 
 ### Usage
 
-    require 'httplog' # require this *after* your HTTP gem of choice
+```ruby
+require 'httplog'
 
+HttpLog.configure do |c|
+    # Enable your client's patching
+    c.enabled_patches = [] # available values [:patron, :excon, :ethon, :httpclient, :httpclient_old, :http_client, :net_http]
+end
+```
+
+Now it is required to call `HttpLog.configure` to enable logging  
 By default, this will log all outgoing HTTP requests and their responses to $stdout on DEBUG level.
 
 ### Notes on content types

--- a/lib/httplog.rb
+++ b/lib/httplog.rb
@@ -2,6 +2,7 @@
 
 require 'httplog/version'
 require 'httplog/configuration'
+require 'httplog/utils/monkey_patcher'
 require 'httplog/http_log'
 require 'httplog/adapters/net_http'
 require 'httplog/adapters/httpclient'

--- a/lib/httplog/adapters/ethon.rb
+++ b/lib/httplog/adapters/ethon.rb
@@ -1,68 +1,73 @@
 # frozen_string_literal: true
 
 if defined?(Ethon)
-  module Ethon
-    class Easy
-      attr_accessor :action_name
+  module HttpLog
+    module Ethon
+      module Easy
+        attr_accessor :action_name
 
-      module Http
-        alias orig_http_request http_request
-        def http_request(url, action_name, options = {})
-          @http_log = options.merge(method: action_name, url: url) # remember this for compact logging
-          orig_http_request(url, action_name, options)
-        end
-      end
-
-      module Operations
-        alias orig_perform perform
-        def perform
-          return orig_perform unless HttpLog.url_approved?(url)
-
-          httplog_add_callback
-
-          bm = Benchmark.realtime { orig_perform }
-
-          url = @http_log[:url]
-          url = "#{url}?#{@http_log[:params]}" if @http_log[:params]
-
-          HttpLog.call(
-            method: @http_log[:method],
-            url: url,
-            request_body: @http_log[:body],
-            request_headers: @http_log[:headers],
-            response_code: @return_code,
-            response_body: @http_log[:response_body],
-            response_headers: @http_log[:response_headers].map { |header| header.split(/:\s/) }.to_h,
-            benchmark: bm,
-            encoding: @http_log[:encoding],
-            content_type: @http_log[:content_type],
-            mask_body: HttpLog.masked_body_url?(@http_log[:url])
-          )
-          return_code
+        module Http
+          def http_request(url, action_name, options = {})
+            @http_log = options.merge(method: action_name, url: url) # remember this for compact logging
+            super(url, action_name, options)
+          end
         end
 
-        def httplog_add_callback
-          # Hack to perform this callback before the cleanup
-          @on_complete ||= []
-          @on_complete.unshift -> (*) do
-            # Not sure where the actual status code is stored - so let's
-            # extract it from the response header.
-            encoding = response_headers.scan(/Content-Encoding: (\S+)/i).flatten.first
-            content_type = response_headers.scan(/Content-Type: (\S+(; charset=\S+)?)/i).flatten.first
+        module Operations
+          def perform
+            return super unless HttpLog.url_approved?(url)
 
-            # Hard to believe that Ethon wouldn't parse out the headers into
-            # an array; probably overlooked it. Anyway, let's do it ourselves:
-            headers = response_headers.split(/\r?\n/).drop(1)
+            httplog_add_callback
 
-            @http_log.merge!(
-              encoding: encoding,
-              content_type: content_type,
-              response_headers: headers,
-              response_body: response_body
+            bm = Benchmark.realtime { super }
+
+            url = @http_log[:url]
+            url = "#{url}?#{@http_log[:params]}" if @http_log[:params]
+
+            HttpLog.call(
+              method: @http_log[:method],
+              url: url,
+              request_body: @http_log[:body],
+              request_headers: @http_log[:headers],
+              response_code: @return_code,
+              response_body: @http_log[:response_body],
+              response_headers: @http_log[:response_headers].map { |header| header.split(/:\s/) }.to_h,
+              benchmark: bm,
+              encoding: @http_log[:encoding],
+              content_type: @http_log[:content_type],
+              mask_body: HttpLog.masked_body_url?(@http_log[:url])
             )
+            return_code
+          end
+
+          def httplog_add_callback
+            # Hack to perform this callback before the cleanup
+            @on_complete ||= []
+            @on_complete.unshift -> (*) do
+              # Not sure where the actual status code is stored - so let's
+              # extract it from the response header.
+              encoding = response_headers.scan(/Content-Encoding: (\S+)/i).flatten.first
+              content_type = response_headers.scan(/Content-Type: (\S+(; charset=\S+)?)/i).flatten.first
+
+              # Hard to believe that Ethon wouldn't parse out the headers into
+              # an array; probably overlooked it. Anyway, let's do it ourselves:
+              headers = response_headers.split(/\r?\n/).drop(1)
+
+              @http_log.merge!(
+                encoding: encoding,
+                content_type: content_type,
+                response_headers: headers,
+                response_body: response_body
+              )
+            end
           end
         end
       end
     end
+  end
+
+  HttpLog::Utils::MonkeyPatcher.register_patch(:ethon) do
+    Ethon::Easy::Http.prepend(HttpLog::Ethon::Easy::Http)
+    Ethon::Easy::Operations.prepend(HttpLog::Ethon::Easy::Operations)
   end
 end

--- a/lib/httplog/adapters/excon.rb
+++ b/lib/httplog/adapters/excon.rb
@@ -1,55 +1,60 @@
 # frozen_string_literal: true
 
 if defined?(Excon)
-  module Excon
-    module HttpLogHelper
-      def httplog_url(datum)
-        @httplog_url ||= ["#{datum[:scheme]}://#{datum[:host]}:#{datum[:port]}#{datum[:path]}", datum[:query]].compact.join('?')
-      end
-    end
-
-    class Socket
-      include Excon::HttpLogHelper
-      alias orig_connect connect
-      def connect
-        host = @data[:proxy] ? @data[:proxy][:host] : @data[:host]
-        port = @data[:proxy] ? @data[:proxy][:port] : @data[:port]
-        HttpLog.log_connection(host, port) if ::HttpLog.url_approved?(httplog_url(@data))
-        orig_connect
-      end
-    end
-
-    class Connection
-      include Excon::HttpLogHelper
-      attr_reader :bm
-
-      alias orig_request request
-      def request(params, &block)
-        result = nil
-        bm = Benchmark.realtime do
-          result = orig_request(params, &block)
+  module HttpLog
+    module Excon
+      module HttpLogHelper
+        def httplog_url(datum)
+          @httplog_url ||= ["#{datum[:scheme]}://#{datum[:host]}:#{datum[:port]}#{datum[:path]}", datum[:query]].compact.join('?')
         end
+      end
 
-        url = httplog_url(@data)
-        return result unless HttpLog.url_approved?(url)
+      module Socket
+        include Excon::HttpLogHelper
+        def connect
+          host = @data[:proxy] ? @data[:proxy][:host] : @data[:host]
+          port = @data[:proxy] ? @data[:proxy][:port] : @data[:port]
+          HttpLog.log_connection(host, port) if ::HttpLog.url_approved?(httplog_url(@data))
+          super
+        end
+      end
 
-        headers = result[:headers] || {}
+      module Connection
+        include Excon::HttpLogHelper
+        attr_reader :bm
 
-        HttpLog.call(
-          method: params[:method],
-          url: url,
-          request_body: @data[:body],
-          request_headers: @data[:headers] || {},
-          response_code: result[:status],
-          response_body: result[:body],
-          response_headers: headers,
-          benchmark: bm,
-          encoding: headers['Content-Encoding'],
-          content_type: headers['Content-Type'],
-          mask_body: HttpLog.masked_body_url?(url)
-        )
-        result
+        def request(params, &block)
+          result = nil
+          bm = Benchmark.realtime do
+            result = super(params, &block)
+          end
+
+          url = httplog_url(@data)
+          return result unless HttpLog.url_approved?(url)
+
+          headers = result[:headers] || {}
+
+          HttpLog.call(
+            method: params[:method],
+            url: url,
+            request_body: @data[:body],
+            request_headers: @data[:headers] || {},
+            response_code: result[:status],
+            response_body: result[:body],
+            response_headers: headers,
+            benchmark: bm,
+            encoding: headers['Content-Encoding'],
+            content_type: headers['Content-Type'],
+            mask_body: HttpLog.masked_body_url?(url)
+          )
+          result
+        end
       end
     end
+  end
+
+  HttpLog::Utils::MonkeyPatcher.register_patch(:excon) do
+    Excon::Socket.prepend(HttpLog::Excon::Socket)
+    Excon::Connection.prepend(HttpLog::Excon::Connection)
   end
 end

--- a/lib/httplog/adapters/http.rb
+++ b/lib/httplog/adapters/http.rb
@@ -1,39 +1,41 @@
 # frozen_string_literal: true
 
-if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
-  module HTTPClientInstrumentation
-    %w[make_request perform].each do |request_method|
-      define_method request_method do |req, options|
-        bm = Benchmark.realtime do
-          @response = super(req, options)
+if defined?(::HTTP)
+  module HttpLog
+    module HTTPClientInstrumentation
+      %w[make_request perform].each do |request_method|
+        define_method request_method do |req, options|
+          bm = Benchmark.realtime do
+            @response = super(req, options)
+          end
+
+          uri = req.uri
+          if HttpLog.url_approved?(uri)
+            body = if defined?(::HTTP::Request::Body)
+                     req.body.respond_to?(:source) ? req.body.source : req.body.instance_variable_get(:@body)
+                   else
+                     req.body
+                   end
+
+            HttpLog.call(
+              method: req.verb,
+              url: uri,
+              request_body: body,
+              request_headers: req.headers,
+              response_code: @response.code,
+              response_body: @response.body,
+              response_headers: @response.headers,
+              benchmark: bm,
+              encoding: @response.headers['Content-Encoding'],
+              content_type: @response.headers['Content-Type'],
+              mask_body: HttpLog.masked_body_url?(uri)
+            )
+
+            body.rewind if body.respond_to?(:rewind)
+          end
+
+          @response
         end
-
-        uri = req.uri
-        if HttpLog.url_approved?(uri)
-          body = if defined?(::HTTP::Request::Body)
-                   req.body.respond_to?(:source) ? req.body.source : req.body.instance_variable_get(:@body)
-                 else
-                   req.body
-                 end
-
-          HttpLog.call(
-            method: req.verb,
-            url: uri,
-            request_body: body,
-            request_headers: req.headers,
-            response_code: @response.code,
-            response_body: @response.body,
-            response_headers: @response.headers,
-            benchmark: bm,
-            encoding: @response.headers['Content-Encoding'],
-            content_type: @response.headers['Content-Type'],
-            mask_body: HttpLog.masked_body_url?(uri)
-          )
-
-          body.rewind if body.respond_to?(:rewind)
-        end
-
-        @response
       end
     end
 
@@ -43,8 +45,10 @@ if defined?(::HTTP::Client) && defined?(::HTTP::Connection)
         super
       end
     end
+  end
 
-    ::HTTP::Client.prepend(HTTPClientInstrumentation)
-    ::HTTP::Connection.prepend(HTTPConnectionInstrumentation)
+  HttpLog::Utils::MonkeyPatcher.register_patch(:http_client) do
+    ::HTTP::Client.prepend(HttpLog::HTTPClientInstrumentation)
+    ::HTTP::Connection.prepend(HttpLog::HTTPConnectionInstrumentation)
   end
 end

--- a/lib/httplog/adapters/httpclient.rb
+++ b/lib/httplog/adapters/httpclient.rb
@@ -1,66 +1,75 @@
 # frozen_string_literal: true
 
 if defined?(::HTTPClient)
-  class HTTPClient
-    private
+  module HttpLog
+    module HTTPClient
+      private
 
-    alias orig_do_get_block do_get_block
-
-    def do_get_block(req, proxy, conn, &block)
-      retryable_response = nil
-      bm = Benchmark.realtime do
-        begin
-          orig_do_get_block(req, proxy, conn, &block)
-        rescue RetryableResponse => e
-          retryable_response = e
+      def do_get_block(req, proxy, conn, &block)
+        retryable_response = nil
+        bm = Benchmark.realtime do
+          begin
+            super(req, proxy, conn, &block)
+          rescue RetryableResponse => e
+            retryable_response = e
+          end
         end
+
+        request_uri = req.header.request_uri
+        if HttpLog.url_approved?(request_uri)
+          res = conn.pop
+          headers = res.headers.transform_keys(&:downcase)
+
+          HttpLog.call(
+            method: req.header.request_method,
+            url: request_uri,
+            request_body: req.body,
+            request_headers: req.headers,
+            response_code: res.status_code,
+            response_body: res.body,
+            response_headers: headers,
+            benchmark: bm,
+            encoding: headers['content-encoding'],
+            content_type: headers['content-type'],
+            mask_body: HttpLog.masked_body_url?(request_uri)
+          )
+          conn.push(res)
+        end
+
+        raise retryable_response unless retryable_response.nil?
       end
 
-      request_uri = req.header.request_uri
-      if HttpLog.url_approved?(request_uri)
-        res = conn.pop
-        headers = res.headers.transform_keys(&:downcase)
-
-        HttpLog.call(
-          method: req.header.request_method,
-          url: request_uri,
-          request_body: req.body,
-          request_headers: req.headers,
-          response_code: res.status_code,
-          response_body: res.body,
-          response_headers: headers,
-          benchmark: bm,
-          encoding: headers['content-encoding'],
-          content_type: headers['content-type'],
-          mask_body: HttpLog.masked_body_url?(request_uri)
-        )
-        conn.push(res)
-      end
-
-      raise retryable_response unless retryable_response.nil?
-    end
-
-    class Session
-      alias orig_create_socket create_socket
-
-      # up to version 2.6, the method signature is `create_socket(site)`; after that,
-      # it's `create_socket(host, port)`
-      if instance_method(:create_socket).arity == 1
+      module SessionOld
+        # up to version 2.6, the method signature is `create_socket(site)`; after that,
+        # it's `create_socket(host, port)`
         def create_socket(site)
           if HttpLog.url_approved?("#{site.host}:#{site.port}")
             HttpLog.log_connection(site.host, site.port)
           end
-          orig_create_socket(site)
-        end
 
-      else
+          super(site)
+        end
+      end
+
+      module SessionLatest
         def create_socket(host, port)
           if HttpLog.url_approved?("#{host}:#{port}")
             HttpLog.log_connection(host, port)
           end
-          orig_create_socket(host, port)
+
+          super(host, port)
         end
       end
     end
+  end
+
+  HttpLog::Utils::MonkeyPatcher.register_patch(:httpclient) do
+    ::HTTPClient.prepend(HttpLog::HTTPClient)
+    ::HTTPClient::Session.prepend(HttpLog::HTTPClient::SessionLatest)
+  end
+
+  HttpLog::Utils::MonkeyPatcher.register_patch(:httpclient_old) do
+    ::HTTPClient.prepend(HttpLog::HTTPClient)
+    ::HTTPClient::Session.prepend(HttpLog::HTTPClient::SessionOld)
   end
 end

--- a/lib/httplog/adapters/net_http.rb
+++ b/lib/httplog/adapters/net_http.rb
@@ -1,50 +1,51 @@
 # frozen_string_literal: true
 
-module Net
-  class HTTP
-    alias orig_request request unless method_defined?(:orig_request)
-    alias orig_connect connect unless method_defined?(:orig_connect)
+module HttpLog
+  module Net
+    module HTTP
+      def request(req, body = nil, &block)
+        url = "http://#{@address}:#{@port}#{req.path}"
 
-    def request(req, body = nil, &block)
-      url = "http://#{@address}:#{@port}#{req.path}"
+        bm = Benchmark.realtime do
+          @response = super(req, body, &block)
+        end
+        body_stream  = req.body_stream
+        request_body = if body_stream
+                         body_stream.to_s # read and rewind for RestClient::Payload::Base
+                         body_stream.rewind if body_stream.respond_to?(:rewind) # RestClient::Payload::Base has no method rewind
+                         body_stream.read
+                       elsif req.body.nil? || req.body.empty?
+                         body
+                       else
+                         req.body
+                       end
 
-      bm = Benchmark.realtime do
-        @response = orig_request(req, body, &block)
+        if HttpLog.url_approved?(url) && started?
+          HttpLog.call(
+            method: req.method,
+            url: url,
+            request_body: request_body,
+            request_headers: req.each_header.collect,
+            response_code: @response.code,
+            response_body: @response.body,
+            response_headers: @response.each_header.collect,
+            benchmark: bm,
+            encoding: @response['Content-Encoding'],
+            content_type: @response['Content-Type'],
+            mask_body: HttpLog.masked_body_url?(url)
+          )
+        end
+
+        @response
       end
-      body_stream  = req.body_stream
-      request_body = if body_stream
-                       body_stream.to_s # read and rewind for RestClient::Payload::Base
-                       body_stream.rewind if body_stream.respond_to?(:rewind) # RestClient::Payload::Base has no method rewind
-                       body_stream.read
-                     elsif req.body.nil? || req.body.empty?
-                       body
-                     else
-                       req.body
-                     end
 
-      if HttpLog.url_approved?(url) && started?
-        HttpLog.call(
-          method: req.method,
-          url: url,
-          request_body: request_body,
-          request_headers: req.each_header.collect,
-          response_code: @response.code,
-          response_body: @response.body,
-          response_headers: @response.each_header.collect,
-          benchmark: bm,
-          encoding: @response['Content-Encoding'],
-          content_type: @response['Content-Type'],
-          mask_body: HttpLog.masked_body_url?(url)
-        )
+      def connect
+        HttpLog.log_connection(@address, @port) if !started? && HttpLog.url_approved?("#{@address}:#{@port}")
+
+        super
       end
-
-      @response
-    end
-
-    def connect
-      HttpLog.log_connection(@address, @port) if !started? && HttpLog.url_approved?("#{@address}:#{@port}")
-
-      orig_connect
     end
   end
 end
+
+HttpLog::Utils::MonkeyPatcher.register_patch(:net_http, HttpLog::Net::HTTP, ::Net::HTTP)

--- a/lib/httplog/adapters/patron.rb
+++ b/lib/httplog/adapters/patron.rb
@@ -1,34 +1,37 @@
 # frozen_string_literal: true
 
-if defined?(Patron)
-  module Patron
-    class Session
-      alias orig_request request
-      def request(action_name, url, headers, options = {})
-        bm = Benchmark.realtime do
-          @response = orig_request(action_name, url, headers, options)
+if defined?(::Patron::Session)
+  module HttpLog
+    module Patron
+      module Session
+        def request(action_name, url, headers, options = {})
+          bm = Benchmark.realtime do
+            @response = super(action_name, url, headers, options)
+          end
+
+          if HttpLog.url_approved?(url)
+            normalized_headers = @response.headers.transform_keys(&:downcase)
+
+            HttpLog.call(
+              method: action_name,
+              url: url,
+              request_body: options[:data],
+              request_headers: headers,
+              response_code: @response.status,
+              response_body: @response.body,
+              response_headers: normalized_headers,
+              benchmark: bm,
+              encoding: normalized_headers['content-encoding'],
+              content_type: normalized_headers['content-type'],
+              mask_body: HttpLog.masked_body_url?(url)
+            )
+          end
+
+          @response
         end
-
-        if HttpLog.url_approved?(url)
-          normalized_headers = @response.headers.transform_keys(&:downcase)
-
-          HttpLog.call(
-            method: action_name,
-            url: url,
-            request_body: options[:data],
-            request_headers: headers,
-            response_code: @response.status,
-            response_body: @response.body,
-            response_headers: normalized_headers,
-            benchmark: bm,
-            encoding: normalized_headers['content-encoding'],
-            content_type: normalized_headers['content-type'],
-            mask_body: HttpLog.masked_body_url?(url)
-          )
-        end
-
-        @response
       end
     end
   end
+
+  HttpLog::Utils::MonkeyPatcher.register_patch(:patron, HttpLog::Patron::Session, Patron::Session)
 end

--- a/lib/httplog/configuration.rb
+++ b/lib/httplog/configuration.rb
@@ -2,6 +2,10 @@
 
 module HttpLog
   class Configuration
+    PatchesError = Class.new(StandardError)
+
+    DEFAULT_PATCHES = %i[net_http].freeze
+
     attr_accessor :enabled,
                   :compact_log,
                   :json_log,
@@ -25,7 +29,8 @@ module HttpLog
                   :prefix_response_lines,
                   :prefix_line_numbers,
                   :json_parser,
-                  :filter_parameters
+                  :filter_parameters,
+                  :enabled_patches
 
     def initialize
       @enabled                 = true
@@ -52,6 +57,13 @@ module HttpLog
       @prefix_line_numbers     = false
       @json_parser             = nil
       @filter_parameters       = %w[password]
+      @enabled_patches         = DEFAULT_PATCHES.dup
+    end
+
+    def enabled_patches=(patches)
+      Utils::MonkeyPatcher.validate!(patches)
+
+      @enabled_patches = patches
     end
   end
 end

--- a/lib/httplog/utils/monkey_patcher.rb
+++ b/lib/httplog/utils/monkey_patcher.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Designed to make all patches optional depending on user's configuration
+module HttpLog
+  module Utils
+    module MonkeyPatcher
+      class << self
+        # @param configuration [HttpLog::Configuration]
+        def apply(configuration)
+          configuration.enabled_patches.each do |patch|
+            registered_patches[patch].call
+          end
+        end
+
+        # @param key [Symbol] provides flexibility in applying multiple patches to a single target
+        # @param patch [Class]
+        # @param target [Class]
+        def register_patch(key, patch = nil, target = nil, &block)
+          if patch && block
+            raise ArgumentError.new('Please provide either a patch and its target OR a block, but not both')
+          end
+
+          if block
+            registered_patches[key] = block
+          else
+            registered_patches[key] = proc do
+              target.send(:prepend, patch) unless target.ancestors.include?(patch)
+            end
+          end
+        end
+
+        def registered_patches
+          @registered_patches ||= {}
+        end
+
+        def validate!(patches)
+          output = registered_patches.keys & patches
+
+          if output.size != patches.size
+            raise HttpLog::Configuration::PatchesError.new("Please check registered patches: #{registered_patches.keys}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 module HttpLog
   describe Configuration do
-    let(:config) { Configuration.new }
+    let(:config) { described_class.new }
 
     describe '#compact_log' do
       it 'defaults to false' do
@@ -16,6 +16,26 @@ module HttpLog
       it 'sets values' do
         config.compact_log = true
         expect(config.compact_log).to eq(true)
+      end
+    end
+
+    describe '#enabled_patches=' do
+      subject { config.enabled_patches = patches }
+
+      context 'when patches invalid' do
+        let(:patches) { %i[foo bar] }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(HttpLog::Configuration::PatchesError)
+        end
+      end
+
+      context 'with valid patches' do
+        let(:patches) { %i[httpclient] }
+
+        it 'successfully sets value' do
+          expect(subject).to eq(patches)
+        end
       end
     end
   end

--- a/spec/httplog/utils/monkey_patcher_spec.rb
+++ b/spec/httplog/utils/monkey_patcher_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HttpLog::Utils::MonkeyPatcher do
+  describe '.apply' do
+    subject { described_class.apply(configuration) }
+
+    let(:configuration) { HttpLog.configuration }
+
+    context 'with default configuration' do
+      before do
+        allow(Net::HTTP).to receive(:prepend)
+      end
+
+      it 'applies default patches' do
+        subject
+
+        expect(HttpLog.configuration.enabled_patches).to eq([:net_http])
+        expect(Net::HTTP).to have_received(:prepend).with(HttpLog::Net::HTTP)
+      end
+    end
+
+    context 'with custom configuration' do
+      let(:enabled_patches) { HttpLog::Utils::MonkeyPatcher.registered_patches.keys }
+
+      before do
+        configuration.enabled_patches = enabled_patches
+      end
+
+      before do
+        allow(Net::HTTP).to receive(:prepend)
+        allow(HTTPClient).to receive(:prepend)
+        allow(HTTPClient::Session).to receive(:prepend)
+        allow(Excon::Socket).to receive(:prepend)
+        allow(Excon::Connection).to receive(:prepend)
+        allow(HTTP::Client).to receive(:prepend)
+        allow(HTTP::Connection).to receive(:prepend)
+        allow(Patron::Session).to receive(:prepend)
+      end
+
+      it 'applies all custom patches' do
+        subject
+
+        expect(HttpLog.configuration.enabled_patches).to eq(enabled_patches)
+        expect(HTTPClient::Session).to have_received(:prepend).with(HttpLog::HTTPClient::SessionLatest)
+        expect(HTTPClient).to have_received(:prepend).with(HttpLog::HTTPClient).twice
+        expect(Excon::Socket).to have_received(:prepend).with(HttpLog::Excon::Socket)
+        expect(Excon::Connection).to have_received(:prepend).with(HttpLog::Excon::Connection)
+        expect(HTTP::Client).to have_received(:prepend).with(HttpLog::HTTPClientInstrumentation)
+        expect(HTTP::Connection).to have_received(:prepend).with(HttpLog::HTTPConnectionInstrumentation)
+        expect(Patron::Session).to have_received(:prepend).with(HttpLog::Patron::Session)
+      end
+    end
+  end
+
+  describe '.register_patch' do
+    let(:target) { Class.new }
+    let(:patch) { Module.new }
+
+    context 'when providing both a block and a patch' do
+      it 'raises an ArgumentError' do
+        expect {
+          described_class.register_patch(:test_patch, patch, target) { puts 'patch' }
+        }.to raise_error(ArgumentError, 'Please provide either a patch and its target OR a block, but not both')
+      end
+    end
+
+    context 'when providing a patch and target' do
+      it 'registers the patch properly' do
+        described_class.register_patch(:test_patch, patch, target)
+        expect(described_class.registered_patches[:test_patch]).to be_a(Proc)
+      end
+    end
+
+    context 'when providing a block' do
+      it 'registers the block as a patch' do
+        block = proc { puts 'patch applied' }
+
+        described_class.register_patch(:test_patch, &block)
+        expect(described_class.registered_patches[:test_patch]).to eq(block)
+      end
+    end
+  end
+
+  describe '.validate!' do
+    subject { described_class.validate!(patches) }
+
+    before { allow(described_class).to receive(:registered_patches).and_return(registered_patches) }
+
+    context 'when all patches are registered' do
+      let(:registered_patches) { { foo: proc {}, bar: proc {} } }
+      let(:patches) { %i[foo bar] }
+
+      it 'does not raise an error' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when some patches are not registered' do
+      let(:registered_patches) { { foo: proc {} } }
+      let(:patches) { %i[foo bar] }
+
+      it 'raises a PatchesError' do
+        expect { subject }.to raise_error(HttpLog::Configuration::PatchesError, /Please check registered patches/)
+      end
+    end
+  end
+end

--- a/spec/lib/http_client_spec.rb
+++ b/spec/lib/http_client_spec.rb
@@ -4,7 +4,12 @@ require 'spec_helper'
 
 describe HTTPClient do
   let(:client) { HTTPClient.new }
-  before { HttpLog.configure { |c| c.logger = Logger.new @log } }
+  before do
+    HttpLog.configure do |c|
+      c.logger = Logger.new @log
+      c.enabled_patches = [:httpclient]
+    end
+  end
 
   it 'works with transparent_gzip_decompression' do
     client.transparent_gzip_decompression = true


### PR DESCRIPTION
Recently, I encountered an issue while adding Sentry to our project. After adding a simple Sentry initializer, all of our HTTP requests started failing with a "Stack too deep" exception. It turned out that both the `sentry-ruby` and `httplog` gems patch the `Net::HTTP` class, but `httplog` does so in a way that creates a loop with other patches.

To resolve this issue, I introduced a lazy monkey patcher that allows users to configure the required patches themselves. This makes the gem more flexible when used alongside other custom patches and resolves the issue mentioned above